### PR TITLE
fix(query processor): thread safe tokenizerME

### DIFF
--- a/engine/src/main/java/com/project/searchengine/queryprocessor/QueryProcessor.java
+++ b/engine/src/main/java/com/project/searchengine/queryprocessor/QueryProcessor.java
@@ -29,7 +29,6 @@ public class QueryProcessor {
     private Ranker ranker;
 
     private final int threadsNum = 20;
-
     private int pageSize = 20;
 
     private Integer resultPagesNumber = 0;

--- a/engine/src/main/java/com/project/searchengine/runner/QueryRunner.java
+++ b/engine/src/main/java/com/project/searchengine/runner/QueryRunner.java
@@ -18,8 +18,8 @@ public class QueryRunner implements CommandLineRunner {
         System.out.println("Starting the query processor...");
         long start = System.currentTimeMillis();
 
-        // String testQuery = "\"coding problems\"";
-        String testQuery = "role";
+        String testQuery = "\"finding nemo\"";
+        // String testQuery = "role";
         queryProcessor.process(testQuery, 0);
         System.out.println("quering took: " + (System.currentTimeMillis() - start) + "ms");
     }

--- a/engine/src/main/java/com/project/searchengine/server/service/PageReferenceService.java
+++ b/engine/src/main/java/com/project/searchengine/server/service/PageReferenceService.java
@@ -5,8 +5,6 @@ import com.project.searchengine.server.model.PageReference;
 import com.project.searchengine.server.repository.PageRepository;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;


### PR DESCRIPTION
Yes, more last-minute changes,

Turns out the issue was with `TokenizerME`, which isn’t thread-safe — unlike the `SimpleTokenizer` we were using before. That’s what caused random tokens being highlighted in snippets, instability, and snippets disappearing into the void randomly.

It was actually throwing exceptions under the hood. I fixed it by giving each thread its own local `tokenizer`.

Test again before merging just to make sure everything’s stable again.